### PR TITLE
Added Docker entrypoint

### DIFF
--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -26,18 +26,15 @@ RUN pipenv install --dev --system
 COPY . /app/{{ cookiecutter.project_slug }}
 
 RUN mkdir -p /logs \
-    && touch /logs/app.log
+    && touch /logs/app.log \
+    && touch /logs/gunicorn.log
 
 ENV PUBLIC_ROOT /public
-RUN make static
+ENV LOG_FILE_PATH /logs
+ENV ENABLE_LOGGING_TO_FILE true
+
+VOLUME /public/media
 
 EXPOSE 8000
 
-VOLUME /public/media
-VOLUME /public/static
-
-
-ENV LOG_FILE_PATH /logs
-ENV ENABLE_LOGGING_TO_FILE true
-ENV GUNICORN_CMD_ARGS "--workers=2 --worker-class=gevent --bind=0.0.0.0:8000"
-CMD ["gunicorn", "{{ cookiecutter.project_slug }}.wsgi"]
+ENTRYPOINT ["/app/{{ cookiecutter.project_slug }}/docker-entrypoint.sh"]

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -47,13 +47,13 @@ quality: ## Run pep8 and Pylint
 validate: quality test ## Run tests and quality checks
 
 detect_missing_migrations:  ## Determine if any apps are missing generated migrations
-	SECRET_KEY=fake DATABASE_URL="sqlite://:memory:" python manage.py makemigrations --check --dry-run || (echo "Migration files are missing. Please run the "makemigrations" management command, and commit the migrations." && false)
+	python manage.py makemigrations --check --dry-run || (echo "Migration files are missing. Please run the "makemigrations" management command, and commit the migrations." && false)
 
 migrate: ## Apply database migrations
-	SECRET_KEY=fake python manage.py migrate --noinput
+	python manage.py migrate --noinput
 
 static: ## Gather all static assets for production
-	SECRET_KEY=fake DATABASE_URL="sqlite://:memory:" python manage.py collectstatic --noinput
+	python manage.py collectstatic --noinput
 
 clean_static: ## Remove all generated static files
 	rm -rf {{ cookiecutter.project_slug }}/public/

--- a/{{ cookiecutter.project_slug }}/docker-entrypoint.sh
+++ b/{{ cookiecutter.project_slug }}/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+mkdir -p /public/static
+make migrate
+make static
+
+# Prepare log files and start outputting logs to stdout
+touch /logs/app.log
+touch /logs/gunicorn.log
+tail -n 0 -f /logs/*.log &
+
+echo Starting Gunicorn...
+gunicorn {{ cookiecutter.project_slug }}.wsgi \
+    --workers=2 \
+    --worker-class=gevent \
+    --bind=0.0.0.0:8000 \
+    --log-file=/logs/gunicorn.log \
+    "$@"


### PR DESCRIPTION
This script allows the container to perform more deployment-related actions—run migrations and collect static files—prior to running. Gunicorn logs are now active, too.