### PR TITLE
Updated docker-entrypoint to stop on errors

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker-entrypoint.sh
+++ b/{{ cookiecutter.project_slug }}/docker-entrypoint.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
 
-mkdir -p /public/static
-make migrate
-make static
+# Exit if any of the lines below fail! This is especially important if, for example, migrations fail.
+# If we do not exit early, we end up running the application without the migrations or, if security groups
+# haven't been properly setup, without a database!
+set -e
 
 # Prepare log files and start outputting logs to stdout
 touch /logs/app.log
 touch /logs/gunicorn.log
 tail -n 0 -f /logs/*.log &
+
+mkdir -p /public/static
+make migrate
+make static
 
 echo Starting Gunicorn...
 gunicorn {{ cookiecutter.project_slug }}.wsgi \


### PR DESCRIPTION
The script now fails if any individual step of the script fails. This helps ensure we don't attempt to start the service without a valid database connection. Additionally, the log setup happens prior to any other steps to ensure we log all errors.